### PR TITLE
Added --xmlCascade parameter

### DIFF
--- a/programs/cvFaces/SegmentorThread.cpp
+++ b/programs/cvFaces/SegmentorThread.cpp
@@ -28,7 +28,9 @@ void SegmentorThread::init(yarp::os::ResourceFinder &rf) {
     cx_d = DEFAULT_CX_D;
     cy_d = DEFAULT_CY_D;    
 
-    int rateMs = DEFAULT_RATE_MS;    
+    int rateMs = DEFAULT_RATE_MS;
+
+    std::string xmlCascade = DEFAULT_XMLCASCADE;
 
     printf("--------------------------------------------------------------\n");
     if (rf.check("help")) {
@@ -40,7 +42,8 @@ void SegmentorThread::init(yarp::os::ResourceFinder &rf) {
         printf("\t--cx_d (default: \"%f\")\n",cx_d);
         printf("\t--cy_d (default: \"%f\")\n",cy_d);
 
-        printf("\t--rateMs (default: \"%d\")\n",rateMs);        
+        printf("\t--rateMs (default: \"%d\")\n",rateMs);
+        printf("\t--xmlCascade (default: \"%s\")\n", xmlCascade.c_str());
         // Do not exit: let last layer exit so we get help from the complete chain.
     }
 
@@ -54,14 +57,16 @@ void SegmentorThread::init(yarp::os::ResourceFinder &rf) {
 
 
 
-    if (rf.check("rateMs")) rateMs = rf.find("rateMs").asInt();    
+    if (rf.check("rateMs")) rateMs = rf.find("rateMs").asInt();
+    if (rf.check("xmlCascade")) xmlCascade = rf.find("xmlCascade").asString();
 
     printf("--------------------------------------------------------------\n");
     if(rf.check("help")) {
         ::exit(1);
     }
 
-    std::string cascade = rf.findFileByName("haarcascade_frontalface_alt.xml");
+    //std::string cascade = rf.findFileByName("haarcascade_frontalface_alt.xml");
+    std::string cascade = xmlCascade;
     if( ! face_cascade.load( cascade ) ) {
         printf("[error] no cascade!\n");
         ::exit(1);

--- a/programs/cvFaces/SegmentorThread.cpp
+++ b/programs/cvFaces/SegmentorThread.cpp
@@ -43,7 +43,7 @@ void SegmentorThread::init(yarp::os::ResourceFinder &rf) {
         printf("\t--cy_d (default: \"%f\")\n",cy_d);
 
         printf("\t--rateMs (default: \"%d\")\n",rateMs);
-        printf("\t--xmlCascade (default: \"%s\")\n", xmlCascade.c_str());
+        printf("\t--xmlCascade [file.xml] (default: \"%s\")\n", xmlCascade.c_str());
         // Do not exit: let last layer exit so we get help from the complete chain.
     }
 

--- a/programs/cvFaces/SegmentorThread.cpp
+++ b/programs/cvFaces/SegmentorThread.cpp
@@ -65,8 +65,7 @@ void SegmentorThread::init(yarp::os::ResourceFinder &rf) {
         ::exit(1);
     }
 
-    //std::string cascade = rf.findFileByName("haarcascade_frontalface_alt.xml");
-    std::string cascade = xmlCascade;
+    std::string cascade = rf.findFileByName(xmlCascade);
     if( ! face_cascade.load( cascade ) ) {
         printf("[error] no cascade!\n");
         ::exit(1);

--- a/programs/cvFaces/SegmentorThread.hpp
+++ b/programs/cvFaces/SegmentorThread.hpp
@@ -44,6 +44,7 @@
 #define DEFAULT_RATE_MS 20
 #define DEFAULT_SEE_BOUNDING 3
 #define DEFAULT_THRESHOLD 55
+#define DEFAULT_XMLCASCADE  "haarcascade_frontalface_alt.xml"
 
 
 namespace teo

--- a/programs/cvFaces/main.cpp
+++ b/programs/cvFaces/main.cpp
@@ -23,16 +23,17 @@
  *
  * @section cvfaces_options SegmentorThread options:
  *
- * |PROPERTY            | DESCRIPTION                           | DEFAULT              |
- * |--------------------|---------------------------------------|----------------------|
- * |help                |                                       |                      |
- * |from                |file.ini                               |                      |
- * |context             |path                                   |                      |
- * |fx_d                |                                       |525.000000            |
- * |fy_d                |                                       |525.000000            |
- * |cx_d                |                                       |319.500000            |
- * |cy_d                |                                       |239.500000            |
- * |rateMs              |                                       |20                    |
+ * |PROPERTY            | DESCRIPTION                           | DEFAULT                       |
+ * |--------------------|---------------------------------------|-------------------------------|
+ * |help                |                                       |                               |
+ * |from                |file.ini                               |                               |
+ * |context             |path                                   |                               |
+ * |fx_d                |                                       |525.000000                     |
+ * |fy_d                |                                       |525.000000                     |
+ * |cx_d                |                                       |319.500000                     |
+ * |cy_d                |                                       |239.500000                     |
+ * |rateMs              |                                       |20                             |
+ * |xmlCascade          |file.xml                               |haarcascade_frontalface_alt.xml|
  *
  *
  *


### PR DESCRIPTION
Added different types of xml  hardcascade in cvFaces. Now, you can configure the program using “–xmlCascade” parameter, continued the filename of hardcascade. All the possibles XML files of hardcascade are located in https://github.com/Itseez/opencv/tree/master/data/haarcascades
